### PR TITLE
Be able to add news story with cli command.

### DIFF
--- a/cmd/send_news_story.go
+++ b/cmd/send_news_story.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/darron/ff/config"
+	"github.com/darron/ff/core"
+	"github.com/darron/ff/service"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	sendCmd.AddCommand(sendNewsStoryCmd)
+	sendNewsStoryCmd.Flags().StringVarP(&recordID, "record", "", "", "Record ID to add News Story To")
+	sendNewsStoryCmd.Flags().StringVarP(&newsURL, "news", "", "", "News story URL to add to Record")
+}
+
+var (
+	sendNewsStoryCmd = &cobra.Command{
+		Use:   "news",
+		Short: "Send core.NewsStory to HTTP endpoint",
+		Run: func(cmd *cobra.Command, args []string) {
+			conf, err := config.Get(
+				config.WithPort(port),
+				config.WithLogger(logLevel, logFormat),
+				config.WithJWTToken(jwtToken))
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = sendNewsStory(conf)
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	recordID string
+	newsURL  string
+)
+
+func sendNewsStory(conf *config.App) error {
+	if recordID == "" {
+		log.Fatal("Need Record id to send add News to")
+	}
+	if newsURL == "" {
+		log.Fatal("Need News URL to add to Record")
+	}
+	client := getHTTPClient()
+	// Make up the proper URL including port and path.
+	u, err := url.JoinPath(conf.GetHTTPEndpoint(), service.NewsStoriesAPIPathFull)
+	if err != nil {
+		return err
+	}
+	conf.Logger.Debug("sendNewsStory", "url", u)
+
+	ns := core.NewsStory{
+		RecordID: recordID,
+		URL:      newsURL,
+	}
+	newsStory, _ := json.Marshal(ns)
+	conf.Logger.Debug("sendNewsStory", "newsStory", string(newsStory))
+	req := getHTTPRequest(http.MethodPost, u, string(newsStory), conf.JWTToken)
+	// Send the HTTP request.
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	conf.Logger.Info(string(body))
+	return nil
+}


### PR DESCRIPTION
So that I can update Records with new News Stories and keep things updated.

It works like this:

```bash
➜  ff git:(main) ✗ bin/ff send news --record 1f4d9319-570c-4f24-b8e4-8378ff0530eb --news https://kamal-deploy.org/docs/installation
time=2023-10-21T19:35:00.931-06:00 level=DEBUG msg=sendNewsStory url=http://localhost:8080/api/v1/stories
time=2023-10-21T19:35:00.931-06:00 level=DEBUG msg=sendNewsStory newsStory="{\"id\":\"\",\"record_id\":\"1f4d9319-570c-4f24-b8e4-8378ff0530eb\",\"url\":\"https://kamal-deploy.org/docs/installation\",\"body_text\":null,\"ai_summary\":null}"
time=2023-10-21T19:35:00.937-06:00 level=INFO msg="\"34e9a591-991b-42fa-b50a-1908cf53b327\"\n"
```

We can see the URL added at the bottom of the screen:

![Screenshot 2023-10-21 at 19 37 50](https://github.com/darron/ff/assets/5176/d0e19ad0-14bc-46fe-849f-50ebea5702e5)
