### PR TITLE
Small fix to handle adding TLS and a remote target to the mix

### DIFF
--- a/cmd/send_news_story.go
+++ b/cmd/send_news_story.go
@@ -24,10 +24,15 @@ var (
 		Use:   "news",
 		Short: "Send core.NewsStory to HTTP endpoint",
 		Run: func(cmd *cobra.Command, args []string) {
+			tlsConfig := config.TLS{
+				DomainNames: tlsDomains,
+			}
 			conf, err := config.Get(
 				config.WithPort(port),
 				config.WithLogger(logLevel, logFormat),
-				config.WithJWTToken(jwtToken))
+				config.WithJWTToken(jwtToken),
+				config.WithTLS(tlsConfig),
+			)
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
Now I can add news stories to live events:

```bash
➜  ff git:(add-news-story-cli-command) ✗ bin/ff send news --record 5bf10c26-6d37-4a6f-90cb-6242c1f6cbf6 --news https://www.langleyadvancetimes.com/editorials-opinion/in-our-view-attacks-cast-a-long-shadow-on-langley-2579770
time=2023-10-21T19:54:02.237-06:00 level=DEBUG msg=sendNewsStory url=https://www.massmurdercanada.org:443/api/v1/stories
time=2023-10-21T19:54:02.237-06:00 level=DEBUG msg=sendNewsStory newsStory="{\"id\":\"\",\"record_id\":\"5bf10c26-6d37-4a6f-90cb-6242c1f6cbf6\",\"url\":\"https://www.langleyadvancetimes.com/editorials-opinion/in-our-view-attacks-cast-a-long-shadow-on-langley-2579770\",\"body_text\":null,\"ai_summary\":null}"
time=2023-10-21T19:54:02.420-06:00 level=INFO msg="\"04147747-1be5-40a8-9036-42dc0d39e666\"\n"
```